### PR TITLE
NFT 민팅 잔여 횟수, 발행된 Rank\Type 테이블 표시기능 작성

### DIFF
--- a/components/MintingModal.tsx
+++ b/components/MintingModal.tsx
@@ -19,9 +19,10 @@ import GemCard from './GemCard';
 interface MintingModalProps {
   isOpen: boolean;
   onClose: () => void;
+  getRemainGemTokens: () => Promise<void>;
 }
 
-const MintingModal: FC<MintingModalProps> = ({ isOpen, onClose }) => {
+const MintingModal: FC<MintingModalProps> = ({ isOpen, onClose, getRemainGemTokens }) => {
   // custom hooks
   const { account } = useAccount();
   const { caver, mintGemTokenContract, saleGemTokenContract } = useCaver();
@@ -46,6 +47,7 @@ const MintingModal: FC<MintingModalProps> = ({ isOpen, onClose }) => {
         .call();
 
         getMetadata(latestMintedGemToken.gemTokenRank, latestMintedGemToken.gemTokenType);
+        getRemainGemTokens();
       }
     } catch(error) {
       console.log(error);
@@ -56,7 +58,7 @@ const MintingModal: FC<MintingModalProps> = ({ isOpen, onClose }) => {
     <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>Miting</ModalHeader>
+          <ModalHeader>Minting</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
             {metadataURI ? (

--- a/components/MintingModal.tsx
+++ b/components/MintingModal.tsx
@@ -20,9 +20,10 @@ interface MintingModalProps {
   isOpen: boolean;
   onClose: () => void;
   getRemainGemTokens: () => Promise<void>;
+  getGemTokenCount: () => Promise<void>;
 }
 
-const MintingModal: FC<MintingModalProps> = ({ isOpen, onClose, getRemainGemTokens }) => {
+const MintingModal: FC<MintingModalProps> = ({ isOpen, onClose, getRemainGemTokens, getGemTokenCount }) => {
   // custom hooks
   const { account } = useAccount();
   const { caver, mintGemTokenContract, saleGemTokenContract } = useCaver();
@@ -48,6 +49,7 @@ const MintingModal: FC<MintingModalProps> = ({ isOpen, onClose, getRemainGemToke
 
         getMetadata(latestMintedGemToken.gemTokenRank, latestMintedGemToken.gemTokenType);
         getRemainGemTokens();
+        getGemTokenCount();
       }
     } catch(error) {
       console.log(error);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from 'react';
 import type { NextPage } from 'next';
-import { Flex, Button, useDisclosure, Text } from '@chakra-ui/react';
+import { Flex, Button, useDisclosure, Text, TableContainer, Table, Thead, Tr, Th, Td, Tbody } from '@chakra-ui/react';
 import MintingModal from '../components/MintingModal';
 import { useCaver } from '../hooks'
 
 
 const Home: NextPage = () => {
   const [remainGemTokens, setRemainGemTokens] = useState<number>(0);
+  const [gemTokenCount, setGemTokenCount] = useState<string[][] | undefined>(
+    undefined
+  );
 
   const { mintGemTokenContract } = useCaver();
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -18,13 +21,29 @@ const Home: NextPage = () => {
       const response = await mintGemTokenContract.methods.totalSupply().call();
 
       setRemainGemTokens(1000 - parseInt(response, 10));
-    } catch (error) {
+    } catch(error) {
       console.log(error);
+    }
+  }
+
+  const getGemTokenCount = async () => {
+    try {
+      if(!mintGemTokenContract) return ;
+
+      const response = await mintGemTokenContract.methods.getGemTokenCount().call();
+
+      console.log(response);
+
+      setGemTokenCount(response);
+
+    } catch(error) {
+      console.error(error);
     }
   }
 
   useEffect(() => {
     getRemainGemTokens();
+    getGemTokenCount();
   }, [mintGemTokenContract]);
 
   return (
@@ -36,12 +55,37 @@ const Home: NextPage = () => {
         alignItems="center" 
         direction="column"
       >
+        <TableContainer mb="4">
+          <Table>
+            <Thead>
+              <Tr>
+                <Th>Rank\Type</Th>
+                <Th>1</Th>
+                <Th>2</Th>
+                <Th>3</Th>
+                <Th>4</Th>
+              </Tr>
+            </Thead>
+            {gemTokenCount?.map((v, i) => {
+              return (
+                <Tbody key={i}>
+                  <Tr>
+                    <Td>{i + 1}</Td>
+                    {v.map((w, j) => {
+                      return <Td key={j}>{w}</Td>;
+                    })}
+                  </Tr>
+                </Tbody>
+              );
+            })}
+          </Table>
+        </TableContainer>
         <Text mb="4">Just [{remainGemTokens}] Gemz Remaining</Text>
         <Button colorScheme="pink" onClick={onOpen}>
           Minting
         </Button>
       </Flex>
-      <MintingModal isOpen={isOpen} onClose={onClose} getRemainGemTokens={getRemainGemTokens}/>
+      <MintingModal isOpen={isOpen} onClose={onClose} getRemainGemTokens={getRemainGemTokens} getGemTokenCount={getGemTokenCount}/>
     </>
   );
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,18 +1,47 @@
+import { useEffect, useState } from 'react';
 import type { NextPage } from 'next';
-import { Flex, Button, useDisclosure } from '@chakra-ui/react';
+import { Flex, Button, useDisclosure, Text } from '@chakra-ui/react';
 import MintingModal from '../components/MintingModal';
+import { useCaver } from '../hooks'
+
 
 const Home: NextPage = () => {
+  const [remainGemTokens, setRemainGemTokens] = useState<number>(0);
+
+  const { mintGemTokenContract } = useCaver();
   const { isOpen, onOpen, onClose } = useDisclosure();
   
+  const getRemainGemTokens = async () => {
+    try {
+      if(!mintGemTokenContract) return ;
+
+      const response = await mintGemTokenContract.methods.totalSupply().call();
+
+      setRemainGemTokens(1000 - parseInt(response, 10));
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  useEffect(() => {
+    getRemainGemTokens();
+  }, [mintGemTokenContract]);
+
   return (
     <>
-      <Flex bg="#E5E5E5" minH="100vh" justifyContent="center" alignItems="center">
+      <Flex 
+        bg="#E5E5E5" 
+        minH="100vh" 
+        justifyContent="center" 
+        alignItems="center" 
+        direction="column"
+      >
+        <Text mb="4">Just [{remainGemTokens}] Gemz Remaining</Text>
         <Button colorScheme="pink" onClick={onOpen}>
           Minting
         </Button>
       </Flex>
-      <MintingModal isOpen={isOpen} onClose={onClose}/>
+      <MintingModal isOpen={isOpen} onClose={onClose} getRemainGemTokens={getRemainGemTokens}/>
     </>
   );
 };


### PR DESCRIPTION
 - [x] 남은 NFT 민팅 수량 표시기능 작성
   - [x] index.tsx에서 useState()를 활용하여 remainGemTokens 작성
   - [x] getRemainGemTokens() 메서드 작성
     - [x] caver-js를 활용하여 totalSupply() 불러오기
   - [x] useEffect()에 메서드 삽입
   - [x] MintingModal.tsx로 props 전달
   - [x] interface에 getRemainGemTokens() 작성
   - [x] 민팅 이후 수량 표시가 갱신되도록 onClickMint()에 메서드 삽입.

 - [x] Gemz NFT Rank, Type 테이블 표시 기능 작성
   - [x] Chakra-UI를 활용한 테이블 작성 (https://chakra-ui.com/docs/components/table/props#td)
   - [x] index.tsx에서 useState()를 활용하여 gemTokenCount 작성
   - [x] getGemTokenCount() 메서드 작성
     - [x] caver-js를 활용하여 getGemTokenCount() 불러오기
   - [x] useEffect()에 메서드 삽입
   - [x] MintingModal.tsx로 props 전달
   - [x] interface에 getGemTokenCount() 작성
   - [x] 민팅 이후 테이블이 갱신되도록 onClickMint()에 메서드 삽입.