### PR TITLE
Page Layout 작성

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,44 @@
+import { FC } from 'react';
+import Link from 'next/link';
+import { Box, Button, Flex, Text } from '@chakra-ui/react';
+
+import { useAccount } from '../hooks';
+
+const Header: FC = () => {
+  const { account } = useAccount();
+
+  return (
+    <Flex 
+      position="fixed"
+      bg="#E88CBD"
+      w="full"
+      color="#FFFFFF"
+      justifyContent="space-between" 
+      px={12} 
+      py={2}
+    >
+      <Box>HarryGemz</Box>
+      <Box>
+        <Link href="/">
+          <Button size="sm" variant="ghost">
+            Home
+          </Button>
+        </Link>
+        <Link href="my-gemz">
+          <Button size="sm" variant="ghost">
+            my-gemz
+          </Button>
+        </Link>
+      </Box>
+      <Box>
+        <Text>
+          {account
+            ? `${account.substr(0, 4)}...${account.substr(account.length - 4, account.length)}`
+            : "please install kaikas wallet"}
+        </Text>
+      </Box>
+    </Flex>
+  );
+}
+
+export default Header;

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,0 +1,19 @@
+import { FC, ReactNode } from 'react';
+import { Box } from '@chakra-ui/react';
+
+import Header from './Header'
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+const Layout: FC<LayoutProps> = ({ children }) => {
+  return (
+  <Box>
+    <Header />
+    {children}
+  </Box>
+  );
+};
+
+export default Layout;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,10 +1,14 @@
 import type { AppProps } from 'next/app';
 import { ChakraProvider } from '@chakra-ui/react';
 
+import Layout from '../components/Layout';
+
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ChakraProvider>
-      <Component {...pageProps} />
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
     </ChakraProvider>
   )
 }

--- a/pages/my-gemz.tsx
+++ b/pages/my-gemz.tsx
@@ -1,0 +1,10 @@
+import { FC } from "react";
+import { Box } from "@chakra-ui/react";
+
+const MyGemz: FC = () => {
+  return (
+  <Box>my-gemz</Box>
+  );
+}
+
+export default MyGemz;


### PR DESCRIPTION
 - [x] Layout 컴포넌트 작성
   - [x] _app.tsx의 <Component {pageProps...} />을 Layout 컴포넌트로 감싸주기.
   - [x] Layout 컴포넌트에는 Header 컴포넌트와 children들이 순서대로 표시될 수 있도록 작성
 - [x] Header 컴포넌트 작성
   - [x] Home과 이후에 만들 my-gemz 홈페이지로 이동할 수 있도록 Nav 만들기. (Link 활용)
   - [x] 로그인된 account Address 일부분 사용자에게 보여주기
     - [x] useAccount() hook을 불러와서 account 정보 가져오기
     - [x] account정보가 없을 경우에는 kaikas 지갑 설치해달라는 Text 표시