### PR TITLE
NFT Sale Page 작성, 판매 및 구매 기능 작성

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -29,6 +29,11 @@ const Header: FC = () => {
             my-gemz
           </Button>
         </Link>
+        <Link href="sale">
+          <Button size="sm" variant="ghost">
+            Sale
+          </Button>
+        </Link>
       </Box>
       <Box>
         <Text>

--- a/components/SaleGemCard.tsx
+++ b/components/SaleGemCard.tsx
@@ -1,21 +1,70 @@
+import { Box, Button, Text } from "@chakra-ui/react";
 import { FC, useEffect } from "react";
-import { useMetadata } from "../hooks";
+import { SALE_GEM_TOKEN_ADDRESS } from "../caverConfig";
+import { useAccount, useCaver, useMetadata } from "../hooks";
 import { GemTokenData } from "../interfaces";
 import GemCard from "./GemCard";
 
 interface SaleGemCardProps {
   gemTokenData: GemTokenData;
+  getSaleGemTokens: () => Promise<void>;
+  setSaleGemTokens: Dispatch<SetStateAction<GemTokenData[] | undefined>>;
 }
 
-const SaleGemCard: FC<SaleGemCardProps> = ({ gemTokenData }) => {
+const SaleGemCard: FC<SaleGemCardProps> = ({
+  gemTokenData, 
+  getSaleGemTokens, 
+  setSaleGemTokens
+}) => {
+  const { account } = useAccount();
+  const { caver, saleGemTokenContract } = useCaver();
   const { metadataURI, getMetadata } = useMetadata();
+
+  const onClickBuy = async () => {
+    try {
+      if (!account || !caver || !saleGemTokenContract) return;
+
+      const response = await caver.klay.sendTransaction({
+        type: "SMART_CONTRACT_EXECUTION",
+        from: account,
+        to: SALE_GEM_TOKEN_ADDRESS,
+        gas: "3000000",
+        data: saleGemTokenContract.methods
+          .purchaseGemToken(gemTokenData.tokenId)
+          .encodeABI(),
+        value: gemTokenData.tokenPrice,
+      });
+
+      if (response.status) {
+        setSaleGemTokens(undefined);
+        getSaleGemTokens();
+      }
+
+    } catch(error) {
+      console.error(error);
+    }
+  }
 
   useEffect(() => {
     getMetadata(gemTokenData.gemTokenRank, gemTokenData.gemTokenType);
   }, []);
-  
+
   return (
-    <GemCard metadataURI={metadataURI}/>
+    <Box>
+      <GemCard metadataURI={metadataURI}/>
+      <Text>
+        {caver?.utils.convertFromPeb(gemTokenData.tokenPrice, "KLAY")} KLAY
+      </Text>
+      <Button 
+        size="sm"
+        ml={2}
+        bg="#E88CBD"
+        color="#FFFFFF"
+        onClick={onClickBuy}
+      >
+        Purchase
+      </Button>
+    </Box>
   )
 }
 

--- a/components/SaleGemCard.tsx
+++ b/components/SaleGemCard.tsx
@@ -1,0 +1,22 @@
+import { FC, useEffect } from "react";
+import { useMetadata } from "../hooks";
+import { GemTokenData } from "../interfaces";
+import GemCard from "./GemCard";
+
+interface SaleGemCardProps {
+  gemTokenData: GemTokenData;
+}
+
+const SaleGemCard: FC<SaleGemCardProps> = ({ gemTokenData }) => {
+  const { metadataURI, getMetadata } = useMetadata();
+
+  useEffect(() => {
+    getMetadata(gemTokenData.gemTokenRank, gemTokenData.gemTokenType);
+  }, []);
+  
+  return (
+    <GemCard metadataURI={metadataURI}/>
+  )
+}
+
+export default SaleGemCard;

--- a/pages/sale.tsx
+++ b/pages/sale.tsx
@@ -39,7 +39,12 @@ const Sale: NextPage = () => {
       templateColumns="repeat(4, 1fr)"
     >
       {saleGemTokens?.map((v, i) => {
-        return <SaleGemCard key={i} gemTokenData={v} />
+        return <SaleGemCard 
+          key={i} 
+          gemTokenData={v} 
+          getSaleGemTokens={getSaleGemTokens}
+          setSaleGemTokens={setSaleGemTokens} 
+        />
       })}
     </Grid>
   )

--- a/pages/sale.tsx
+++ b/pages/sale.tsx
@@ -1,0 +1,48 @@
+import { Grid } from "@chakra-ui/react";
+import { NextPage } from "next";
+import { useEffect, useState } from "react";
+import SaleGemCard from "../components/SaleGemCard";
+import { useCaver } from "../hooks";
+import { GemTokenData } from "../interfaces";
+
+const Sale: NextPage = () => {
+  const [saleGemTokens, setSaleGemTokens] = useState<GemTokenData[] | undefined> (
+    undefined
+  )
+
+  const { saleGemTokenContract } = useCaver();
+
+  const getSaleGemTokens = async () => {
+    try {
+      if(!saleGemTokenContract) return ;
+
+      const response = await saleGemTokenContract.methods
+        .getSaleGemTokens()
+        .call();
+
+        setSaleGemTokens(response);
+    } catch(error) {
+      console.error(error);
+    }
+  }
+
+  useEffect(() => {
+    getSaleGemTokens();
+  }, [saleGemTokenContract]);
+
+  return (
+    <Grid 
+      bg="#FFD3E8" 
+      px={12} 
+      py={16} 
+      minH="100vh" 
+      templateColumns="repeat(4, 1fr)"
+    >
+      {saleGemTokens?.map((v, i) => {
+        return <SaleGemCard key={i} gemTokenData={v} />
+      })}
+    </Grid>
+  )
+}
+
+export default Sale;


### PR DESCRIPTION
 - sale 페이지 작성
   - [x] getSaleGemTokens()
     - [x] useCaver Hook을 활용하여 saleGemTokenContract를 불러온다.
     - [x] 조회함수 getSaleGemTokens를 활용하여 반환값을 response에 담는다.
     - [x] 세터함수 setSaleGemTokens를 활용하여 saleGemTokens에 response값을 저장한다.
     - [x] 이후에 getSaleGemTokens, setSaleGemTokens를 SaleGemCard 컴포넌트에 Props로 넘겨준다.

 - SaleGemCard 컴포넌트 작성
   - [x] onClickBuy()
     - [x] useCaver Hook을 활용하여 saleGemTokenContract를 불러온다.
     - [x] purchaseGemToken 메서드에 gemTokenData.tokenId를 파라미터로 넘겨준다.
     - [x] 이때 sendTransaction에 value 값도 써주는걸 잊지말자, value에는 gemTokenData.tokenPrice가 들어간다.
       - _why? purchaseGemToken 메서드는 payable로 정의 되어있기 때문에 value 값이 필요로 한다._
